### PR TITLE
Feat: OAuth query params + extra props for `children`

### DIFF
--- a/frontend/src/context/dappContext.js
+++ b/frontend/src/context/dappContext.js
@@ -1,0 +1,15 @@
+/* https://www.robinwieruch.de/react-usecontext-hook */
+import {createContext, useContext} from "react";
+
+// Create the context
+const DappContext = createContext(null);
+
+// Create a custom provider component
+const DappContextProvider = ({value, children}) => (
+  <DappContext.Provider value={value}>{children}</DappContext.Provider>
+);
+
+// Create a hook to grab the value directly
+const useDappContext = () => useContext(DappContext);
+
+export {DappContextProvider, useDappContext};

--- a/frontend/src/layouts/Dapp.js
+++ b/frontend/src/layouts/Dapp.js
@@ -1,9 +1,12 @@
-import React, {useState} from "react";
+import React, {useState, useEffect} from "react";
 import {authenticate} from "ceramic/index.js";
 import Sidebar from "components/Sidebar.js";
 import WalletInfo from "components/WalletInfo.js";
 
+import {useLocation} from "react-router-dom";
+
 const Dapp = ({children}) => {
+  /* Ceramic Code */
   const [loading, setLoading] = useState(false);
   const [ceramicId, setCeramicId] = useState("");
 
@@ -22,6 +25,21 @@ const Dapp = ({children}) => {
         setLoading(false);
       });
   };
+
+  /* OAuth Callback stuff */
+  // On every route change, it will look for query strings
+  // And print each key/value pair
+  const location = useLocation();
+
+  useEffect(() => {
+    const queryString = location.search;
+    const params = new URLSearchParams(queryString);
+
+    params.forEach((value, key) => {
+      // We can access the key/value here, to save it or whatever
+      console.log(`key: ${key} / value: ${value}`);
+    });
+  }, [location]);
 
   return (
     <div className="flex h-screen overflow-hidden">

--- a/frontend/src/layouts/Dapp.js
+++ b/frontend/src/layouts/Dapp.js
@@ -42,7 +42,7 @@ const Dapp = ({children}) => {
   }, [location]);
 
   /* Extra prop, to test the extra prop adding */
-  const extraProp = "test";
+  const [extraProp, setExtraProp] = useState("test");
 
   return (
     <div className="flex h-screen overflow-hidden">
@@ -58,7 +58,7 @@ const Dapp = ({children}) => {
         />
         {/* we use cloneElement to add extra props  to the children */}
         {/* https://reactjs.org/docs/react-api.html#cloneelement */}
-        <section>{cloneElement(children, {extraProp})}</section>
+        <section>{cloneElement(children, {extraProp, setExtraProp})}</section>
       </main>
     </div>
   );

--- a/frontend/src/layouts/Dapp.js
+++ b/frontend/src/layouts/Dapp.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from "react";
+import React, {useState, useEffect, cloneElement} from "react";
 import {authenticate} from "ceramic/index.js";
 import Sidebar from "components/Sidebar.js";
 import WalletInfo from "components/WalletInfo.js";
@@ -41,6 +41,9 @@ const Dapp = ({children}) => {
     });
   }, [location]);
 
+  /* Extra prop, to test the extra prop adding */
+  const extraProp = "test";
+
   return (
     <div className="flex h-screen overflow-hidden">
       {/* Sidebar */}
@@ -53,7 +56,9 @@ const Dapp = ({children}) => {
           loading={loading}
           ceramicId={ceramicId}
         />
-        <section>{children}</section>
+        {/* we use cloneElement to add extra props  to the children */}
+        {/* https://reactjs.org/docs/react-api.html#cloneelement */}
+        <section>{cloneElement(children, {extraProp})}</section>
       </main>
     </div>
   );

--- a/frontend/src/layouts/Dapp.js
+++ b/frontend/src/layouts/Dapp.js
@@ -1,9 +1,11 @@
-import React, {useState, useEffect, cloneElement} from "react";
+import React, {useState, useEffect} from "react";
 import {authenticate} from "ceramic/index.js";
 import Sidebar from "components/Sidebar.js";
 import WalletInfo from "components/WalletInfo.js";
 
 import {useLocation} from "react-router-dom";
+
+import {DappContextProvider} from "context/dappContext";
 
 const Dapp = ({children}) => {
   /* Ceramic Code */
@@ -41,9 +43,6 @@ const Dapp = ({children}) => {
     });
   }, [location]);
 
-  /* Extra prop, to test the extra prop adding */
-  const [extraProp, setExtraProp] = useState("test");
-
   return (
     <div className="flex h-screen overflow-hidden">
       {/* Sidebar */}
@@ -56,9 +55,10 @@ const Dapp = ({children}) => {
           loading={loading}
           ceramicId={ceramicId}
         />
-        {/* we use cloneElement to add extra props  to the children */}
-        {/* https://reactjs.org/docs/react-api.html#cloneelement */}
-        <section>{cloneElement(children, {extraProp, setExtraProp})}</section>
+        {/* Use the Provider, which exposes the value to the children */}
+        <DappContextProvider value={"whatever"}>
+          <section>{children}</section>
+        </DappContextProvider>
       </main>
     </div>
   );

--- a/frontend/src/pages/Dapp/Settings.js
+++ b/frontend/src/pages/Dapp/Settings.js
@@ -1,7 +1,13 @@
-const Settings = () => (
-  <main>
-    <h1>Settings page</h1>
-  </main>
-);
+import {useDappContext} from "context/dappContext";
+
+const Settings = () => {
+  const value = useDappContext();
+
+  return (
+    <main>
+      <h1>Settings page {value}</h1>
+    </main>
+  );
+};
 
 export default Settings;


### PR DESCRIPTION
This PR:
- Adds a `useEffect` to check the `location` for changes. Once one is detected, we loop through the params. We can do whatever to those `key`s and `value`s there.
![image](https://user-images.githubusercontent.com/15834664/135366862-4fba6491-9dc7-491e-8457-e7956c17ec6d.png)


- ~~Uses `cloneElement` to clone the `children` and add `extraProp`, this is just an example, we can add whatever extra props there.~~
~~Notice `extraProp` in the `prop` list~~
![image](https://user-images.githubusercontent.com/15834664/135366922-1bea80b8-64a5-407f-8ba2-258ddfee6546.png)

** EDIT **
- Now using React's Context. I think this will scale better
Notice how we're getting the DappContextProvider in the tree. And we can use the hook `useDappContext()` to get the current value.
![image](https://user-images.githubusercontent.com/15834664/135377198-2ab37663-d00a-493d-90c0-0fc9864a5635.png)

